### PR TITLE
Fix token refresh recursion

### DIFF
--- a/server/util/spotify.py
+++ b/server/util/spotify.py
@@ -480,7 +480,6 @@ def get_access_token_from_db(user_id, app_id):
     tuple: A tuple containing the access token and refresh token. If the access token is not found, returns None.
     """
     result = firebase_operations.get_userlinkedapps_access_refresh(user_id, app_id)
-    print(result)
     if not result:
         logger.error(f"Access token not found for user_id: {user_id}")
         return f"Access token not found for user_id: {user_id}", None
@@ -488,6 +487,6 @@ def get_access_token_from_db(user_id, app_id):
     access_token, refresh_token = result["access_token"], result["refresh_token"]
     if test_token(access_token) != 200:
         refresh_access_token_and_update_db(user_id, refresh_token, app_id)
-        get_access_token_from_db(user_id, app_id)
+        return get_access_token_from_db(user_id, app_id)
 
     return access_token, refresh_token


### PR DESCRIPTION
## Summary
- avoid debug print and return updated tokens in `get_access_token_from_db`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683f44bd4f74833186036aff6acfe27f