### PR TITLE
Add assertion for error response in playlist duration test

### DIFF
--- a/server/tests/test_spotify_micro_service.py
+++ b/server/tests/test_spotify_micro_service.py
@@ -121,6 +121,8 @@ def test_playlist_duration_invalid_payload(client, app):
     headers = get_spotify_auth_headers(app, scopes=["spotify"])
     response = client.post("/spotify-micro-service/playlist_duration", json={}, headers=headers)
     assert response.status_code == 400, "Expected 400 error for missing required fields in payload"
+    data = response.get_json()
+    assert "error" in data, "Expected an error message in the response"
 
 
 def test_playlist_duration_exception(monkeypatch, client, app):


### PR DESCRIPTION
## Summary
- test that invalid payload returns an error message

## Testing
- `pytest server/tests/test_spotify_micro_service.py::test_playlist_duration_invalid_payload -q` *(fails: FIREBASE_CC_JSON environment variable not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f461ba4048331ba5de864b885639e